### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-Resnet50Imagenet.yml
+++ b/.github/workflows/docker-Resnet50Imagenet.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/TF-Resnet50-Imagenet
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker-StableDiffusion.yml
+++ b/.github/workflows/docker-StableDiffusion.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/stable-diffusion
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker-TF-ModelGarden.yml
+++ b/.github/workflows/docker-TF-ModelGarden.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/tf-models
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker-cancernet.yml
+++ b/.github/workflows/docker-cancernet.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/TF-Cancernet
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker-dcgmexporter.yml
+++ b/.github/workflows/docker-dcgmexporter.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/dcgmexporter
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker-lafe-prostatecancer.yml
+++ b/.github/workflows/docker-lafe-prostatecancer.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/tf-prostatecancer
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker-pytorch-denoising.yml
+++ b/.github/workflows/docker-pytorch-denoising.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/Pytorch-Denoising
         username: ${{ secrets.DOCKER_USER }}

--- a/.github/workflows/docker-pytorch-mnist.yml
+++ b/.github/workflows/docker-pytorch-mnist.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v4
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: esparig/pytorch-mnist
         username: ${{ secrets.DOCKER_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore